### PR TITLE
Feat: Panel Refresh Button

### DIFF
--- a/public/app/features/dashboard/dashgrid/PanelHeader/PanelHeader.tsx
+++ b/public/app/features/dashboard/dashgrid/PanelHeader/PanelHeader.tsx
@@ -35,7 +35,7 @@ export const PanelHeader: FC<Props> = ({ panel, error, isViewing, isEditing, dat
 
   return (
     <>
-      <PanelHeaderLoadingIndicator state={data.state} onClick={onCancelQuery} />
+      <PanelHeaderLoadingIndicator state={data.state} onClick={onCancelQuery} panel={panel} />
       <PanelHeaderCorner
         panel={panel}
         title={panel.title}

--- a/public/app/features/dashboard/dashgrid/PanelHeader/PanelHeaderLoadingIndicator.tsx
+++ b/public/app/features/dashboard/dashgrid/PanelHeader/PanelHeaderLoadingIndicator.tsx
@@ -4,13 +4,26 @@ import React, { FC } from 'react';
 import { GrafanaTheme2, LoadingState } from '@grafana/data';
 import { Icon, Tooltip, useStyles2 } from '@grafana/ui';
 
+import { PanelModel } from '../../state';
+import { refreshPanel } from '../../utils/panel';
+
 interface Props {
   state: LoadingState;
   onClick: () => void;
+  panel: PanelModel;
 }
 
-export const PanelHeaderLoadingIndicator: FC<Props> = ({ state, onClick }) => {
+export const PanelHeaderLoadingIndicator: FC<Props> = ({ state, onClick, panel }) => {
   const styles = useStyles2(getStyles);
+  if ([LoadingState.NotStarted, LoadingState.Done, LoadingState.Error].includes(state)) {
+    return (
+      <div className="panel-loading" onClick={() => refreshPanel(panel)}>
+        <Tooltip content="Refresh Panel">
+          <Icon name="sync" />
+        </Tooltip>
+      </div>
+    );
+  }
 
   if (state === LoadingState.Loading) {
     return (

--- a/public/app/features/dashboard/dashgrid/PanelStateWrapper.tsx
+++ b/public/app/features/dashboard/dashgrid/PanelStateWrapper.tsx
@@ -586,7 +586,7 @@ export class PanelStateWrapper extends PureComponent<Props, State> {
     const title = panel.getDisplayTitle();
     const noPadding: PanelPadding = plugin.noPadding ? 'none' : 'md';
     const leftItems = [
-      <PanelHeaderLoadingIndicator state={data.state} onClick={onCancelQuery} key="loading-indicator" />,
+      <PanelHeaderLoadingIndicator state={data.state} onClick={onCancelQuery} panel={panel} key="loading-indicator" />,
     ];
 
     if (config.featureToggles.newPanelChromeUI) {

--- a/public/app/features/dashboard/services/TimeSrv.ts
+++ b/public/app/features/dashboard/services/TimeSrv.ts
@@ -276,7 +276,6 @@ export class TimeSrv {
   // resume auto-refresh based on old dashboard refresh property
   resumeAutoRefresh() {
     this.autoRefreshPaused = false;
-    this.refreshTimeModel();
   }
 
   setTime(time: RawTimeRange, updateUrl = true) {


### PR DESCRIPTION
**What is this feature?**

1- Refresh button per panel in a dashboard
2- Disable refresh all panels when exiting editing of one panel

**Why do we need this feature?**

we need to have a refresh button for each panel since Grafana only has a refresh button that refreshes the whole dashboard and some panels might not be required to refresh and they need a long time to refresh. So, refreshing all the panels is not always the case. Also refreshing all the panels when exiting the edit of some panel is not a behavior that we want.
