### PR TITLE
Fix: minor issue with panel refresh for text panels

### DIFF
--- a/public/app/features/dashboard/dashgrid/PanelHeader/PanelHeaderLoadingIndicator.tsx
+++ b/public/app/features/dashboard/dashgrid/PanelHeader/PanelHeaderLoadingIndicator.tsx
@@ -15,7 +15,7 @@ interface Props {
 
 export const PanelHeaderLoadingIndicator: FC<Props> = ({ state, onClick, panel }) => {
   const styles = useStyles2(getStyles);
-  if ([LoadingState.NotStarted, LoadingState.Done, LoadingState.Error].includes(state)) {
+  if ([LoadingState.Done, LoadingState.Error].includes(state)) {
     return (
       <div className="panel-loading" onClick={() => refreshPanel(panel)}>
         <Tooltip content="Refresh Panel">


### PR DESCRIPTION
**What is this feature?**

remove refresh button for text panels
![image](https://user-images.githubusercontent.com/42721791/213425795-bf66202c-5e90-4202-9f1e-739169725ce3.png)


**Why do we need this feature?**

refresh button for text panels overlaps with the text when the title of the panel is empty string. Also, text panels don't need to be refreshed.