### PR TITLE
Feat: disable lazy loading in dashboard settings

### DIFF
--- a/public/app/features/dashboard/components/DashboardSettings/GeneralSettings.tsx
+++ b/public/app/features/dashboard/components/DashboardSettings/GeneralSettings.tsx
@@ -3,7 +3,7 @@ import { connect, ConnectedProps } from 'react-redux';
 
 import { TimeZone } from '@grafana/data';
 import { config } from '@grafana/runtime';
-import { CollapsableSection, Field, Input, RadioButtonGroup, TagsInput } from '@grafana/ui';
+import { CollapsableSection, Field, Input, RadioButtonGroup, Switch, TagsInput } from '@grafana/ui';
 import { Page } from 'app/core/components/PageNew/Page';
 import { FolderPicker } from 'app/core/components/Select/FolderPicker';
 import { updateTimeZoneDashboard, updateWeekStartDashboard } from 'app/features/dashboard/state/actions';
@@ -77,6 +77,11 @@ export function GeneralSettingsUnconnected({
     updateWeekStart(weekStart);
   };
 
+  const onEagerLoadChange = () => {
+    dashboard.eagerLoad = !dashboard.eagerLoad;
+    setRenderCounter(renderCounter + 1);
+  }
+
   const onTagsChange = (tags: string[]) => {
     dashboard.tags = tags;
     setRenderCounter(renderCounter + 1);
@@ -122,6 +127,14 @@ export function GeneralSettingsUnconnected({
             description="Set to read-only to disable all editing. Reload the dashboard for changes to take effect"
           >
             <RadioButtonGroup value={dashboard.editable} options={editableOptions} onChange={onEditableChange} />
+          </Field>
+
+          <Field label="Eager Load Panels">
+            <Switch
+              id="eager-load-toggle"
+              value={!!dashboard.eagerLoad}
+              onChange={onEagerLoadChange}
+            />
           </Field>
         </div>
 

--- a/public/app/features/dashboard/dashgrid/DashboardGrid.tsx
+++ b/public/app/features/dashboard/dashgrid/DashboardGrid.tsx
@@ -196,6 +196,7 @@ export class DashboardGrid extends PureComponent<Props, State> {
         isViewing={panel.isViewing}
         width={width}
         height={height}
+        lazy={!this.props.dashboard.eagerLoad}
       />
     );
   }

--- a/public/app/features/dashboard/dashgrid/PanelHeader/PanelHeaderLoadingIndicator.tsx
+++ b/public/app/features/dashboard/dashgrid/PanelHeader/PanelHeaderLoadingIndicator.tsx
@@ -15,7 +15,7 @@ interface Props {
 
 export const PanelHeaderLoadingIndicator: FC<Props> = ({ state, onClick, panel }) => {
   const styles = useStyles2(getStyles);
-  if ([LoadingState.NotStarted, LoadingState.Done, LoadingState.Error].includes(state)) {
+  if ([LoadingState.Done, LoadingState.Error].includes(state)) {
     return (
       <div className="panel-loading" onClick={() => refreshPanel(panel)}>
         <Tooltip content="Refresh Panel">

--- a/public/app/features/dashboard/state/DashboardModel.ts
+++ b/public/app/features/dashboard/state/DashboardModel.ts
@@ -99,6 +99,7 @@ export class DashboardModel implements TimeModel {
   private panelsAffectedByVariableChange: number[] | null;
   private appEventsSubscription: Subscription;
   private lastRefresh: number;
+  eagerLoad: boolean;
 
   // ------------------
   // not persisted
@@ -156,6 +157,7 @@ export class DashboardModel implements TimeModel {
     this.links = data.links ?? [];
     this.gnetId = data.gnetId || null;
     this.panels = map(data.panels ?? [], (panelData: any) => new PanelModel(panelData));
+    this.eagerLoad = data.eagerLoad;
     this.ensurePanelsHaveIds();
     this.formatDate = this.formatDate.bind(this);
 


### PR DESCRIPTION
**What is this feature?**

this feature adds a switch to the dashboard settings to disable lazy loading the panels of the dashboard

![image](https://user-images.githubusercontent.com/42721791/223113205-2f3594e4-0909-409b-9bd4-f00c8870328d.png)


**Why do we need this feature?**

some dashboards require all the panels to be loaded once the dashboard page is opened
